### PR TITLE
chore(meta): specifying dependencies using `.tool-versions`

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -28,8 +28,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-elixir@v1
       with:
-        elixir-version: '1.14.1' # Define the elixir version [required]
-        otp-version: '25.1' # Define the OTP version [required]
+        elixir-version: '1.14.3' # Define the elixir version [required]
+        otp-version: '25.2' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 25.2
+elixir 1.14.3-otp-25
+nodejs 19.3.0

--- a/README.md
+++ b/README.md
@@ -54,13 +54,7 @@
     asdf plugin-add elixir
     asdf plugin-add nodejs
 
-    asdf install erlang latest
-    asdf install elixir latest
-    asdf install nodejs latest
-
-    asdf global erlang latest
-    asdf global elixir latest
-    asdf global nodejs latest
+    asdf install
    ```
 
 ### Installation


### PR DESCRIPTION
The latest versions from Elixir and Erlang have already changed, so it might be good to add a `.tool-versions` file, so that install is more streamlined, because README can be misleading

I also noticed that the versions in `fly.yaml` workflow were out of date, so I updated them too.

This is a very small PR, and not the most useful tbh, but I didn't know what to get started on to help the project. I'd love to do more contributions, please let me know what can I do after this. Thank you friends :)~